### PR TITLE
'clear' method respects 'backgroundColor'

### DIFF
--- a/Source/SignatureView.m
+++ b/Source/SignatureView.m
@@ -73,7 +73,10 @@
 - (void)clear {
     self.blank = YES;
     
-    [self clearWithColor:[UIColor whiteColor]];
+    UIColor *newBackgroundColor = (self.backgroundColor && self.backgroundColor != [UIColor clearColor]) ?
+    self.backgroundColor : [UIColor whiteColor];
+    
+    [self clearWithColor:newBackgroundColor];
     [self clearWithColor:[UIColor clearColor]];
 }
 


### PR DESCRIPTION
When the signature is cleared using `[self clear]`, the view is now cleared with the view's current background color, rather than overwriting the background with a white background.
